### PR TITLE
fix image sizes which were in tuple

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+
+*.pyc
+
+resnet_640x640/coco_det_finetune_resnet_640x640_checkpoint
+
+resnet_640x640/coco_det_finetune_resnet_640x640_ev_object_detection_validation_p0.4cocoeval.pkl
+
+resnet_640x640/coco_det_finetune_resnet_640x640_ev_object_detection_validation_p0.4_result.json
+
+resnet_640x640/coco_det_finetune_resnet_640x640_config.json
+
+resnet_640x640/coco_det_finetune_resnet_640x640_ckpt-71148.index
+
+resnet_640x640/coco_det_finetune_resnet_640x640_ckpt-71148.data-00000-of-00001

--- a/models/ar_model.py
+++ b/models/ar_model.py
@@ -42,14 +42,14 @@ class Model(tf.keras.models.Model):
     mlp_ratio = config.dim_mlp // config.dim_att
     if config.resnet_variant == 'c1':
       self.encoder = VisionTransformer(
-          config.image_size[0], config.image_size[1], config.patch_size,
+          config.image_size, config.image_size, config.patch_size,
           config.num_encoder_layers, config.dim_att, mlp_ratio,
           config.num_heads, config.drop_path, config.drop_units,
           config.drop_att, config.pos_encoding, config.use_cls_token,
           name='vit')
     else:
       self.encoder = ResNetTransformer(
-          config.image_size[0], config.image_size[1], config.resnet_variant,
+          config.image_size, config.image_size, config.resnet_variant,
           config.resnet_depth, config.resnet_width_multiplier,
           config.resnet_sk_ratio, config.num_encoder_layers, config.dim_att,
           mlp_ratio, config.num_heads, config.drop_path, config.drop_units,

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tensorflow-addons
 tensorflow-text
 pycocotools
 scikit-image
+numpy


### PR DESCRIPTION
According to [issue No.23](https://github.com/google-research/pix2seq/issues/23), I had a minor fixes on code.

These is also a minor change needs to be applied on last cell in Notebook. I did not put it in this request because of many changes on raw ipynb file:

```python
features, labels = data_utils.preprocess_eval(
    features,
    labels,
    max_image_size=[config.model.image_size,config.model.image_size],
    max_instances_per_image=1)
```